### PR TITLE
Manual paste + DB duplicate fix

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,8 +6,12 @@
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.257" />
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/drawable/ic_launcher_background.xml" value="0.257" />
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/layout/activity_answers.xml" value="0.28351449275362317" />
+        <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/layout/activity_history.xml" value="0.31354166666666666" />
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/layout/activity_main.xml" value="0.2994791666666667" />
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/layout/card_layout.xml" value="0.31354166666666666" />
+        <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/layout/toolbar.xml" value="0.31354166666666666" />
+        <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/menu/default_toolbar.xml" value="0.31354166666666666" />
+        <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/menu/history_toolbar.xml" value="0.31354166666666666" />
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml" value="0.257" />
         <entry key="..\:/GitHub/KahootHackApp/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml" value="0.257" />
         <entry key="..\:/Users/deancan/Documents/KahootHackApp/app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.2985" />

--- a/app/src/main/java/com/dalibortrampota/kahoothackapp/MainActivity.kt
+++ b/app/src/main/java/com/dalibortrampota/kahoothackapp/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.dalibortrampota.kahoothackapp
 
 import android.content.Intent
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -14,6 +15,7 @@ import android.widget.TextView
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.drawable.DrawableCompat
 import com.dalibortrampota.kahoothackapp.database.QuestionsDatabase
 import com.dalibortrampota.kahoothackapp.database.QuizInsert
 import com.google.gson.Gson
@@ -35,6 +37,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var imageView: ImageView
     private lateinit var statusText: TextView
     private lateinit var idPrompt: EditText
+    private lateinit var modeSwitchButton: MenuItem
     private var editMode = false
 
     private var QUIZ_ID_REGEX_ONE: Regex = Regex("details/(.+)")
@@ -90,6 +93,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.default_toolbar, menu)
+        if(menu != null) modeSwitchButton = menu.findItem(R.id.action_paste)
         return super.onCreateOptionsMenu(menu)
     }
 
@@ -218,18 +222,35 @@ class MainActivity : AppCompatActivity() {
         idPrompt.visibility = View.GONE
         button.setText("SELECT IMAGE")
 
+        if(this::modeSwitchButton.isInitialized) {
+            //val typedValue = TypedValue()
+            //theme.resolveAttribute(android.R.attr.colorPrimary, typedValue, true)
+            //DrawableCompat.setTint(modeSwitchButton.icon, typedValue.data)
+            DrawableCompat.setTint(modeSwitchButton.icon, Color.WHITE)
+        }
     }
 
     private fun editQuizID(foundID: String = "", showStatusMessage: Boolean = true){
         editMode = true
         if(showStatusMessage)
             setStatusText(true, "Extracted ID wasn't resolved properly. Check characters like o/0 or i/l/f")
+        if(resources.getString(R.string.mode) == "Day") idPrompt.setBackgroundColor(resources.getColor(R.color.primaryLight))
+        else idPrompt.setBackgroundColor(resources.getColor(R.color.primaryDark))
+
         idPrompt.setText(foundID)
         idPrompt.setHint("Paste quiz ID here")
         idPrompt.visibility = View.VISIBLE
         button.setText("Confirm Quiz ID")
 
+        if(this::modeSwitchButton.isInitialized) {
+            //val typedValue = TypedValue()
+            //theme.resolveAttribute(android.R.attr.colorSecondary, typedValue, true)
+            //DrawableCompat.setTint(modeSwitchButton.icon, typedValue.data)
+            if(resources.getString(R.string.mode) == "Day") DrawableCompat.setTint(modeSwitchButton.icon, resources.getColor(R.color.bgDark))
+            else DrawableCompat.setTint(modeSwitchButton.icon, resources.getColor(R.color.bgDark))
+        }
     }
+
 
     private fun detectQuizID(str: String): String? {
         var match = QUIZ_ID_REGEX_ONE.find(str)

--- a/app/src/main/java/com/dalibortrampota/kahoothackapp/database/QuestionsDatabase.kt
+++ b/app/src/main/java/com/dalibortrampota/kahoothackapp/database/QuestionsDatabase.kt
@@ -3,7 +3,7 @@ package com.dalibortrampota.kahoothackapp.database
 import android.content.Context
 import androidx.room.*
 
-@Database(entities = [Quiz::class], version = 1, exportSchema = false)
+@Database(entities = [Quiz::class], version = 2, exportSchema = false)
 abstract class QuestionsDatabase : RoomDatabase(){
     abstract fun questionsDao(): QuestionsDao
 

--- a/app/src/main/java/com/dalibortrampota/kahoothackapp/database/QuestionsDatabase.kt
+++ b/app/src/main/java/com/dalibortrampota/kahoothackapp/database/QuestionsDatabase.kt
@@ -3,7 +3,7 @@ package com.dalibortrampota.kahoothackapp.database
 import android.content.Context
 import androidx.room.*
 
-@Database(entities = [Quiz::class], version = 2, exportSchema = false)
+@Database(entities = [Quiz::class], version = 1, exportSchema = false)
 abstract class QuestionsDatabase : RoomDatabase(){
     abstract fun questionsDao(): QuestionsDao
 

--- a/app/src/main/java/com/dalibortrampota/kahoothackapp/database/Quiz.kt
+++ b/app/src/main/java/com/dalibortrampota/kahoothackapp/database/Quiz.kt
@@ -2,7 +2,7 @@ package com.dalibortrampota.kahoothackapp.database
 
 import androidx.room.*
 
-@Entity(tableName = "questions")
+@Entity(tableName = "questions", indices = [Index(value = ["quiz_name"], unique = true)])
 data class Quiz (
     @ColumnInfo(name = "quiz_name") val quiz_name: String?,
     @ColumnInfo(name = "questions") val answers: String?,
@@ -18,7 +18,7 @@ data class QuizInsert(
 
 @Dao
 interface QuestionsDao {
-    @Insert(entity = Quiz::class)
+    @Insert(entity = Quiz::class, onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(data: QuizInsert)
 
     @Query("SELECT * FROM questions ORDER BY uid DESC")

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -63,7 +63,8 @@
         android:hint="edit ID"
         android:inputType="textShortMessage"
         android:textAlignment="center"
-        android:textColor="@color/white"
+        android:textColor="@color/bgLight"
+        android:textColorHint="@color/bgLight"
         android:textSize="20sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -72,6 +73,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.626"
-        tools:visibility="gone" />
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/default_toolbar.xml
+++ b/app/src/main/res/menu/default_toolbar.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_paste"
+        android:icon="?attr/actionModePasteDrawable"
+        android:title="Manual paste"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/action_history"
         android:icon="@drawable/ic_baseline_history_24"
         android:title="History"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,7 +2,7 @@
     <!-- Base application theme. -->
 
 
-
+    <string name="mode">Night</string>
     <style name="Theme.KahootHackApp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/primaryDark</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mode">Day</string>
     <!-- Base application theme. -->
     <style name="Theme.KahootHackApp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->


### PR DESCRIPTION
This PR adds another button to the toolbar, allowing users to paste quiz ID manually rather than detecting from an image. 
Also loading the same quiz ID multiple times won't save multiple times to the history but updates the previous DB entry